### PR TITLE
Fix `spacing` function to return value as `%`unit

### DIFF
--- a/packages/components/src/styles/tools.ts
+++ b/packages/components/src/styles/tools.ts
@@ -111,4 +111,4 @@ const opacityHex = {
 export const createHexWithOpacity = (color: string, value: keyof typeof opacityHex) => `${color}${opacityHex[value]}`;
 
 // spacing
-export const spacing = (px: number) => calc(px).divide(360).multiply('100vw');
+export const spacing = (px: number) => calc(px).divide(360).multiply('100%');


### PR DESCRIPTION
### 해결책이 무엇 이니?

spacing 함수 vm 형태로 반환하도록 개발 했었는데 웹에서도 사용하려면 % 으로 사용해야 원하는 결과물이 나와서 수정한 PR입니다.

### 사이트의 어떤 영역에 영향을 미칩니까?

(사이트의 어떤 부분이 영향을 받았는지 및 *if*코드가 다른 영역에 닿았는지 설명)

### 기타 참고 사항

(개발자 또는 QA 테스터에게 유용한 추가 정보 추가)

### 체크리스트

-   [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
-   [ ] 콘솔에 오류나 경고가 없습니다.

### Commit message

```
and :

-
```
