### PR TITLE
Add Dialog component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "extends": [
     "airbnb",
     "eslint:recommended",
+    "prettier",
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
     "plugin:@typescript-eslint/recommended"
@@ -20,8 +21,10 @@
     "sourceType": "module",
     "project": ["./packages/**/tsconfig.json"]
   },
-  "plugins": ["react", "@typescript-eslint", "unused-imports", "simple-import-sort"],
+  "plugins": ["react", "@typescript-eslint", "prettier", "unused-imports", "simple-import-sort"],
   "rules": {
+    "prettier/prettier": ["error"],
+
     // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
     "react/jsx-filename-extension": [1, { "extensions": [".tsx"] }],
     "react/jsx-props-no-spreading": "off",

--- a/packages/components/src/Button/Button.css.ts
+++ b/packages/components/src/Button/Button.css.ts
@@ -3,6 +3,7 @@ import { recipe } from '@vanilla-extract/recipes';
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 
 import { vars } from '../styles/global.css';
+import { setStackOrder } from '../styles/tools';
 
 const buttonSize = {
   large: '64px',
@@ -43,7 +44,10 @@ export const buttonStyle = style({
   justifyContent: 'center',
   fontWeight: 600,
   cursor: 'pointer',
+  color: vars.colors.white,
 });
+
+export const buttonStackOrderStyle = style({ zIndex: setStackOrder('interaction') });
 
 export const buttonRecipe = recipe({
   base: { borderWidth: 0 },
@@ -78,7 +82,7 @@ export const buttonRecipe = recipe({
           height: 'inherit',
           background: vars.colors.primary,
           borderRadius: 'inherit',
-          zIndex: -2,
+          zIndex: setStackOrder('interaction') - 2,
         },
         '::after': {
           content: '',
@@ -90,7 +94,7 @@ export const buttonRecipe = recipe({
           background: vars.colors.gradientDark,
           transition: `opacity ${vars.transitions.duration.fast} ${vars.transitions.timing.easeOut}`,
           borderRadius: 'inherit',
-          zIndex: -1,
+          zIndex: setStackOrder('interaction') - 1,
           opacity: 0,
         },
         selectors: { '&:hover:after': { opacity: 1 } },

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,7 +1,9 @@
+import { cloneElement, isValidElement } from 'react';
 import classNames from 'classnames';
+import { gradientOutlineRecipe } from 'styles/gradient.css';
 
 import { ButtonNext, ButtonPrev } from './ButtonPrevNext/ButtonPrevNext';
-import { buttonRecipe, buttonSprinkles, buttonStyle } from './Button.css';
+import { buttonRecipe, buttonSprinkles, buttonStackOrderStyle, buttonStyle } from './Button.css';
 import { ButtonProps, IconOnlyProps, WithIconProps } from './Button.types';
 import { getBackground } from './Button.utils';
 
@@ -15,24 +17,26 @@ function Button(props: ButtonProps) {
     iconPosition = 'right',
     iconOnly,
     label,
-    variant = 'solid',
+    variant: variantFromParent,
     background: backgroundFromParent,
     borderColor: borderColorFromParent,
     ...rest
   } = props;
 
+  const variant =
+    backgroundFromParent && !variantFromParent ? undefined : variantFromParent || 'solid';
   const width = iconOnly ? sizeFromParent : 'parent';
+  const size = variant === 'transparent' ? 'custom' : sizeFromParent;
+  const borderColor = variant === 'outline' ? borderColorFromParent : undefined;
   const background = getBackground(
     variant,
     'background' in props ? backgroundFromParent : undefined,
   );
-  const borderColor = variant === 'outline' ? borderColorFromParent : undefined;
-  const size = variant === 'transparent' ? 'custom' : sizeFromParent;
 
-  // TODO 아래 문제 타입 에러가 왜 나는지 확인 필요
+  const iconElement =
+    isValidElement(children) && cloneElement(children, { className: buttonStackOrderStyle });
+
   return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     <button
       {...rest}
       type={type}
@@ -45,12 +49,13 @@ function Button(props: ButtonProps) {
           background,
           borderColor: 'borderColor' in props ? borderColor : undefined,
         }),
+        borderColor === 'gradient' && gradientOutlineRecipe({ background: 'white' }),
         rest.className,
       )}
     >
-      {iconPosition === 'left' && children}
-      {label}
-      {iconPosition === 'right' && children}
+      {iconPosition === 'left' && iconElement}
+      {label && <span className={buttonStackOrderStyle}>{label}</span>}
+      {iconPosition === 'right' && iconElement}
     </button>
   );
 }

--- a/packages/components/src/Button/Button.types.ts
+++ b/packages/components/src/Button/Button.types.ts
@@ -10,9 +10,10 @@ type IconPosition = 'left' | 'right';
 
 type ButtonAttributes = JSX.IntrinsicElements['button'];
 
-interface ButtonCommonProps extends ButtonAttributes {
+interface ButtonCommonProps extends Omit<ButtonAttributes, 'children'> {
   size?: ButtonSize;
-  label?: string;
+  label: string;
+  children?: ReactElement;
 }
 
 export type OutlineVariantProps = ButtonCommonProps & {
@@ -33,7 +34,7 @@ export type TransparentVariantProps = ButtonCommonProps & {
 
 export type ButtonVariantProps = SolidVariantProps | OutlineVariantProps | TransparentVariantProps;
 
-export type IconOnlyProps = Omit<ButtonVariantProps, 'children' | 'label'> & {
+export type IconOnlyProps = Omit<ButtonVariantProps, 'label'> & {
   iconOnly: true;
   children: ReactElement;
   label?: undefined;
@@ -45,5 +46,5 @@ export type WithIconProps = ButtonVariantProps & {
 export type ButtonProps = Omit<ButtonVariantProps, 'label'> & {
   iconOnly?: unknown;
   iconPosition?: unknown;
-  label?: unknown;
+  label?: string;
 };

--- a/packages/components/src/Button/Button.utils.ts
+++ b/packages/components/src/Button/Button.utils.ts
@@ -1,15 +1,15 @@
 import { ButtonBackground, ButtonVariant } from './Button.types';
 
 export function getBackground(
-  variant: ButtonVariant,
+  variant: ButtonVariant | undefined,
   background?: ButtonBackground,
 ): ButtonBackground {
-  if (background) {
+  if (background || !variant) {
     return background;
   }
 
   return (<Record<ButtonVariant, ButtonBackground>>{
-    solid: 'gradient',
+    solid: 'primary',
     outline: 'transparent',
   })[variant];
 }

--- a/packages/components/src/Button/ButtonPrevNext/ButtonPrevNext.css.ts
+++ b/packages/components/src/Button/ButtonPrevNext/ButtonPrevNext.css.ts
@@ -3,14 +3,12 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '../../styles/global.css';
 import { outlineLinearGradientVar } from '../../styles/gradient.css';
 
-// TODO hover 스타일 추가 - 버튼과는 다른 속성으로 구현해야함 `background-image`
-export const buttonPrevStyle = style({});
+const commonStyle = { '::before': { display: 'none' } };
 
-export const buttonNextStyle = style(
-  {
-    vars: {
-      [outlineLinearGradientVar]:
-      vars.colors.invertedGradientDark,
-    },
-  },
-);
+// TODO hover 스타일 추가 - 버튼과는 다른 속성으로 구현해야함 `background-image`
+export const buttonPrevStyle = style({ ...commonStyle });
+
+export const buttonNextStyle = style({
+  vars: { [outlineLinearGradientVar]: vars.colors.invertedGradientDark },
+  ...commonStyle,
+});

--- a/packages/components/src/Button/ButtonPrevNext/ButtonPrevNext.tsx
+++ b/packages/components/src/Button/ButtonPrevNext/ButtonPrevNext.tsx
@@ -20,6 +20,7 @@ export function ButtonPrev(props: ButtonNextProps) {
         className,
       )}
       borderColor="gradient"
+      iconOnly
     >
       <ArrowGradientPrev />
     </Button>
@@ -37,6 +38,7 @@ export function ButtonNext(props: ButtonNextProps) {
         className,
       )}
       borderColor="gradient"
+      iconOnly
     >
       <ArrowGradientNext />
     </Button>

--- a/packages/components/src/Dialog/Dialog.css.ts
+++ b/packages/components/src/Dialog/Dialog.css.ts
@@ -1,0 +1,36 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '../styles/global.css';
+
+export const backdropRecipe = recipe({
+  base: { backgroundColor: 'transparent' },
+  variants: {
+    hasBackdrop: {
+      false: { backgroundColor: 'transparent' },
+      true: {
+        backgroundColor: vars.colors.black,
+        opacity: 0.7,
+      },
+    },
+  },
+});
+
+export const dialogStyle = style({
+  position: 'relative',
+  padding: '24px 20px',
+  textAlign: 'center',
+  borderRadius: '16px',
+  boxShadow: '0px 4px 28px rgba(0, 0, 0, 0.08)',
+  backgroundColor: vars.colors.white,
+});
+
+export const dialogRecipe = recipe({
+  base: { padding: '24px 20px' },
+  variants: {
+    dialogType: {
+      true: { paddingTop: '50px' },
+      false: {},
+    },
+  },
+});

--- a/packages/components/src/Dialog/Dialog.hooks.ts
+++ b/packages/components/src/Dialog/Dialog.hooks.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+export function useDialog(id?: string) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleOpenDialog = () => {
+    setIsOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsOpen(false);
+  };
+
+  return {
+    id,
+    isOpen,
+    setIsOpen,
+    handleOpenDialog,
+    handleCloseDialog,
+  };
+}

--- a/packages/components/src/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/Dialog/Dialog.stories.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Button from '../Button/Button';
+import Text from '../Text/Text';
+
+import Dialog from './Dialog';
+import { useDialog } from './Dialog.hooks';
+import { DialogMessageType, DialogProps } from './Dialog.types';
+
+export default {
+  title: 'Feedback/Dialog',
+  component: Dialog,
+} as ComponentMeta<typeof Dialog>;
+
+interface DialogSampleProps extends DialogProps {
+  dialogType?: DialogMessageType;
+}
+function DialogSample(props: DialogSampleProps) {
+  const { isOpen, onClose, dialogType, ...rest } = props;
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} type={dialogType} {...rest}>
+      <Dialog.Content>
+        <Text as="p">편지 작성을 완료 하겠어요?</Text>
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button label="취소" onClick={onClose} variant="outline" borderColor="gradient" />
+        <Button label="확인" background="gradient" />
+      </Dialog.Actions>
+    </Dialog>
+  );
+}
+
+const Templates: ComponentStory<typeof Dialog> = (args) => {
+  const { isOpen, handleOpenDialog, handleCloseDialog } = useDialog();
+  return (
+    <>
+      <Button label="Open Dialog" onClick={handleOpenDialog} />
+      <DialogSample {...args} isOpen={isOpen} onClose={handleCloseDialog} />
+    </>
+  );
+};
+
+export const Base = Templates.bind({});
+Base.parameters = { controls: { exclude: ['type'] } };
+
+const WithTypeTemplates: ComponentStory<typeof Dialog> = (args) => {
+  const { type: typeFromParent } = args;
+  const { isOpen, handleOpenDialog, handleCloseDialog } = useDialog();
+  const [dialogType, setDialogType] = useState<DialogMessageType>();
+
+  const handleOpenDialogByTypeClick = (type: DialogMessageType) => () => {
+    setDialogType(type);
+    handleOpenDialog();
+  };
+  return (
+    <>
+      <div style={{ width: 400, display: 'flex', gap: 10 }}>
+        <Button label="Caution" onClick={handleOpenDialogByTypeClick('caution')} />
+        <Button label="Success" onClick={handleOpenDialogByTypeClick('success')} />
+        <Button label="Info" onClick={handleOpenDialogByTypeClick('info')} />
+      </div>
+      <DialogSample
+        onClose={handleCloseDialog}
+        dialogType={dialogType || typeFromParent}
+        {...args}
+        isOpen={isOpen}
+      />
+    </>
+  );
+};
+
+export const DialogTypes = WithTypeTemplates.bind({});

--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -1,0 +1,34 @@
+import classNames from 'classnames';
+
+import { Dialog as BDialog } from '@blueprintjs/core';
+
+import DialogActions from './DialogActions/DialogActions';
+import DialogContent from './DialogContent/DialogContent';
+import DialogTypeImage from './DialogTypeImage/DialogTypeImage';
+import { backdropRecipe, dialogRecipe, dialogStyle } from './Dialog.css';
+import { DialogProps } from './Dialog.types';
+
+function Dialog(props: DialogProps) {
+  const { className, children, type, hasBackdrop = true, ...rest } = props;
+
+  return (
+    <BDialog
+      {...rest}
+      backdropClassName={backdropRecipe({ hasBackdrop })}
+      hasBackdrop={hasBackdrop}
+      transitionName="dialogTransition"
+      className={classNames(
+        dialogStyle,
+        dialogRecipe({ dialogType: type !== undefined }),
+        className,
+      )}
+      isCloseButtonShown={false}
+      lazy
+    >
+      {type && <DialogTypeImage type={type} />}
+      {children}
+    </BDialog>
+  );
+}
+
+export default Object.assign(Dialog, { Actions: DialogActions, Content: DialogContent });

--- a/packages/components/src/Dialog/Dialog.types.ts
+++ b/packages/components/src/Dialog/Dialog.types.ts
@@ -1,0 +1,8 @@
+import { DialogProps as BDialogProps } from '@blueprintjs/core';
+
+export type DialogMessageType = 'caution' | 'info' | 'success';
+
+export interface DialogProps extends Omit<BDialogProps, 'isCloseButtonShown'> {
+  hasBackdrop?: boolean;
+  type?: DialogMessageType;
+}

--- a/packages/components/src/Dialog/DialogActions/DialogActions.css.ts
+++ b/packages/components/src/Dialog/DialogActions/DialogActions.css.ts
@@ -1,0 +1,3 @@
+import { style } from '@vanilla-extract/css';
+
+export const dialogActionsStyle = style({ gap: '12px' });

--- a/packages/components/src/Dialog/DialogActions/DialogActions.tsx
+++ b/packages/components/src/Dialog/DialogActions/DialogActions.tsx
@@ -1,0 +1,23 @@
+import classNames from 'classnames';
+
+import { layoutSprinkles } from '../../styles/layout.css';
+
+import { dialogActionsStyle } from './DialogActions.css';
+import { DialogActionsProps } from './DialogActions.types';
+
+function DialogActions(props: DialogActionsProps) {
+  const { flex = 'row', className, ...rest } = props;
+
+  return (
+    <div
+      className={classNames(
+        dialogActionsStyle,
+        layoutSprinkles({ display: 'flex', flex }),
+        className,
+      )}
+      {...rest}
+    />
+  );
+}
+
+export default DialogActions;

--- a/packages/components/src/Dialog/DialogActions/DialogActions.types.ts
+++ b/packages/components/src/Dialog/DialogActions/DialogActions.types.ts
@@ -1,0 +1,5 @@
+type DialogActionsAttributes = JSX.IntrinsicElements['div'];
+
+export interface DialogActionsProps extends DialogActionsAttributes {
+  flex?: 'row' | 'column';
+}

--- a/packages/components/src/Dialog/DialogContent/DialogContent.css.ts
+++ b/packages/components/src/Dialog/DialogContent/DialogContent.css.ts
@@ -1,0 +1,3 @@
+import { style } from '@vanilla-extract/css';
+
+export const dialogContentStyle = style({ padding: '24px 0' });

--- a/packages/components/src/Dialog/DialogContent/DialogContent.tsx
+++ b/packages/components/src/Dialog/DialogContent/DialogContent.tsx
@@ -1,0 +1,12 @@
+import classNames from 'classnames';
+
+import { dialogContentStyle } from './DialogContent.css';
+import { DialogContentProps } from './DialogContent.types';
+
+function DialogContent(props: DialogContentProps) {
+  const { className, ...rest } = props;
+
+  return <div className={classNames(dialogContentStyle, className)} {...rest} />;
+}
+
+export default DialogContent;

--- a/packages/components/src/Dialog/DialogContent/DialogContent.types.ts
+++ b/packages/components/src/Dialog/DialogContent/DialogContent.types.ts
@@ -1,0 +1,1 @@
+export type DialogContentProps = JSX.IntrinsicElements['div'];

--- a/packages/components/src/Dialog/DialogTypeImage/DialogTypeImage.css.ts
+++ b/packages/components/src/Dialog/DialogTypeImage/DialogTypeImage.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css';
+
+export const imageWrapperClassName = style({
+  position: 'absolute',
+  top: '-50px',
+  left: '50%',
+  transform: 'translateX(-50%)',
+});

--- a/packages/components/src/Dialog/DialogTypeImage/DialogTypeImage.tsx
+++ b/packages/components/src/Dialog/DialogTypeImage/DialogTypeImage.tsx
@@ -1,0 +1,24 @@
+import { ReactComponent as Warning } from '../../assets/images/caution.svg';
+import { ReactComponent as Success } from '../../assets/images/confirm.svg';
+import { ReactComponent as Info } from '../../assets/images/draft-letter.svg';
+
+import { imageWrapperClassName } from './DialogTypeImage.css';
+import { DialogTypeImageProps } from './DialogTypeImage.types';
+
+function DialogTypeImage(props: DialogTypeImageProps) {
+  const { type } = props;
+
+  if (!type) {
+    return null;
+  }
+
+  const image = {
+    caution: <Warning />,
+    info: <Info />,
+    success: <Success />,
+  };
+
+  return <div className={imageWrapperClassName}>{image[type]}</div>;
+}
+
+export default DialogTypeImage;

--- a/packages/components/src/Dialog/DialogTypeImage/DialogTypeImage.types.ts
+++ b/packages/components/src/Dialog/DialogTypeImage/DialogTypeImage.types.ts
@@ -1,0 +1,5 @@
+import { DialogMessageType } from '../Dialog.types';
+
+export interface DialogTypeImageProps {
+  type: DialogMessageType;
+}

--- a/packages/components/src/assets/images/arrow-gradient-front.svg
+++ b/packages/components/src/assets/images/arrow-gradient-front.svg
@@ -1,9 +1,9 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.4615 6L20 12M20 12L14.4615 18M20 12H6.5M4 12H3" stroke="url(#paint0_linear_681_3947)" stroke-linecap="round"/>
-<defs>
-<linearGradient id="paint0_linear_681_3947" x1="20" y1="12.0984" x2="3" y2="12.0984" gradientUnits="userSpaceOnUse">
-<stop stop-color="#A788FF"/>
-<stop offset="1" stop-color="#F5B5FF"/>
-</linearGradient>
-</defs>
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path stroke="url(#arrow-gradient-front_svg__a)" stroke-linecap="round" d="M14.461 6 20 12m0 0-5.539 6M20 12H6.5M4 12H3"/>
+  <defs>
+    <linearGradient id="arrow-gradient-front_svg__a" x1="20" x2="3" y1="12.098" y2="12.098" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#A788FF"/>
+      <stop offset="1" stop-color="#F5B5FF"/>
+    </linearGradient>
+  </defs>
 </svg>

--- a/packages/components/src/assets/images/caution.svg
+++ b/packages/components/src/assets/images/caution.svg
@@ -1,0 +1,34 @@
+<svg width="100" height="100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <mask id="caution_svg__b" width="100" height="100" x="0" y="0" maskUnits="userSpaceOnUse" style="mask-type:alpha">
+    <circle cx="50" cy="50" r="50" fill="url(#caution_svg__a)"/>
+  </mask>
+  <g mask="url(#caution_svg__b)">
+    <path fill="url(#caution_svg__c)" d="M-1 0h101v100H-1z"/>
+    <circle cx="50" cy="50" r="49.5" stroke="url(#caution_svg__d)"/>
+    <path fill="url(#caution_svg__e)" d="M54.4 52.563a3.4 3.4 0 0 1-3.394 3.187h-2.012a3.4 3.4 0 0 1-3.394-3.188l-1.374-21.95A3.4 3.4 0 0 1 47.62 27h4.76a3.4 3.4 0 0 1 3.394 3.612L54.4 52.562Z"/>
+    <rect width="12" height="11.5" x="56" y="73" fill="url(#caution_svg__f)" rx="5.75" transform="rotate(-180 56 73)"/>
+  </g>
+  <defs>
+    <linearGradient id="caution_svg__a" x1="0" x2="95" y1="7.5" y2="84.5" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#A788FF"/>
+      <stop offset="1" stop-color="#F5B5FF"/>
+    </linearGradient>
+    <linearGradient id="caution_svg__c" x1="-1" x2="94.191" y1="7.5" y2="85.427" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FEFFC0"/>
+      <stop offset="1" stop-color="#FFC5E1"/>
+    </linearGradient>
+    <linearGradient id="caution_svg__d" x1="110" x2="19" y1="110.5" y2="8.5" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF7E7E"/>
+      <stop offset=".464" stop-color="#FFA4D5"/>
+      <stop offset="1" stop-color="#FFDEF0"/>
+    </linearGradient>
+    <linearGradient id="caution_svg__e" x1="56" x2="44.912" y1="57.313" y2="12.96" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF4B8C"/>
+      <stop offset="1" stop-color="#FF4B8C" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="caution_svg__f" x1="56" x2="57.866" y1="72.375" y2="91.038" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF4B8C"/>
+      <stop offset="1" stop-color="#FF4B8C" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/packages/components/src/assets/images/confirm.svg
+++ b/packages/components/src/assets/images/confirm.svg
@@ -1,0 +1,40 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_744_4322" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+<circle cx="50" cy="50" r="50" fill="#F2E6FF"/>
+</mask>
+<g mask="url(#mask0_744_4322)">
+<rect x="-1" width="101" height="100" fill="url(#paint0_linear_744_4322)"/>
+<circle cx="50" cy="50" r="49.5" stroke="url(#paint1_linear_744_4322)"/>
+<rect x="42" y="60" width="16" height="16" rx="8" fill="url(#paint2_linear_744_4322)"/>
+<path d="M30 40C30 28.9543 38.9543 20 50 20C61.0457 20 70 28.9543 70 40V60C70 62.2091 68.2091 64 66 64H34C31.7909 64 30 62.2091 30 60V40Z" fill="url(#paint3_linear_744_4322)"/>
+<rect x="25" y="61" width="50" height="8" rx="4" fill="url(#paint4_linear_744_4322)"/>
+<path d="M44 43L48.6154 48L56 40" stroke="url(#paint5_radial_744_4322)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_744_4322" x1="62.5" y1="100" x2="35" y2="-3.49999" gradientUnits="userSpaceOnUse">
+<stop offset="0.187294" stop-color="#F9B5FF"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint1_linear_744_4322" x1="-22" y1="23.5" x2="109" y2="79" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF8484"/>
+<stop offset="1" stop-color="#FFC4BC"/>
+</linearGradient>
+<linearGradient id="paint2_linear_744_4322" x1="47.5" y1="80" x2="60.6563" y2="54.3495" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF3087"/>
+<stop offset="0.489583" stop-color="#AA34F2" stop-opacity="0.479167"/>
+<stop offset="0.661458" stop-color="#E230FF" stop-opacity="0.4"/>
+</linearGradient>
+<linearGradient id="paint3_linear_744_4322" x1="30" y1="17.5" x2="71.2538" y2="73.0692" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFC0C4"/>
+<stop offset="1" stop-color="#FF2574"/>
+</linearGradient>
+<linearGradient id="paint4_linear_744_4322" x1="65" y1="71.5" x2="64.2932" y2="56.8824" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF3087"/>
+<stop offset="0.901534" stop-color="#FFC4DC"/>
+</linearGradient>
+<radialGradient id="paint5_radial_744_4322" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(48.5 44) rotate(-1.19349) scale(24.0052 36.0078)">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</radialGradient>
+</defs>
+</svg>

--- a/packages/components/src/assets/images/draft-letter.svg
+++ b/packages/components/src/assets/images/draft-letter.svg
@@ -1,0 +1,92 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_708_3996" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+<circle cx="50" cy="50" r="50" fill="#F2E6FF"/>
+</mask>
+<g mask="url(#mask0_708_3996)">
+<rect x="-1" width="101" height="100" fill="url(#paint0_linear_708_3996)"/>
+<path d="M10.3902 61.669C10.3902 58.7443 11.8114 56.0019 14.201 54.3156L45.9857 31.8858C49.0968 29.6904 53.2529 29.6904 56.364 31.8858L88.1487 54.3156C90.5383 56.0019 91.9595 58.7443 91.9595 61.669V97.1428C91.9595 99.9043 89.7209 102.143 86.9595 102.143H15.3902C12.6288 102.143 10.3902 99.9043 10.3902 97.1428V61.669Z" fill="url(#paint1_linear_708_3996)" stroke="white" stroke-width="2"/>
+<rect x="28" y="41" width="47" height="41" rx="1" fill="url(#paint2_linear_708_3996)" stroke="url(#paint3_linear_708_3996)" stroke-width="2"/>
+<rect x="40" y="51" width="22" height="3" rx="1.5" fill="url(#paint4_linear_708_3996)"/>
+<rect x="50" y="59" width="12" height="3" rx="1.5" fill="url(#paint5_linear_708_3996)"/>
+<path d="M10.4084 96.98V67.1189C10.4084 66.3905 11.1624 65.9064 11.8248 66.2097L49.9865 83.683C50.7829 84.0476 51.6988 84.0461 52.4938 83.6787L90.2839 66.2171C90.9465 65.9109 91.7033 66.3949 91.7033 67.1249V96.98C91.7033 99.7414 89.4647 101.98 86.7033 101.98H15.4084C12.647 101.98 10.4084 99.7414 10.4084 96.98Z" fill="url(#paint6_linear_708_3996)" stroke="white" stroke-width="2"/>
+<path d="M91.5522 101.98H10.93C7.87998 101.98 6.77588 97.9574 9.39856 96.4004L44.6048 75.4994C48.6957 73.0707 53.7866 73.0707 57.8775 75.4994L93.0837 96.4004C95.7064 97.9574 94.6023 101.98 91.5522 101.98Z" fill="url(#paint7_linear_708_3996)" stroke="white" stroke-width="2"/>
+<g filter="url(#filter0_f_708_3996)">
+<circle cx="87.5" cy="41.5" r="1.5" fill="white"/>
+</g>
+<circle cx="87.5" cy="41.5" r="1" fill="white"/>
+<g filter="url(#filter1_f_708_3996)">
+<circle cx="71" cy="17" r="2" fill="white"/>
+</g>
+<circle cx="71" cy="17" r="1.5" fill="white"/>
+<g filter="url(#filter2_f_708_3996)">
+<circle cx="29.5" cy="29.5" r="2.5" fill="white"/>
+</g>
+<circle cx="29.5" cy="29.5" r="1.5" fill="white"/>
+<g filter="url(#filter3_f_708_3996)">
+<circle cx="16.5" cy="26.5" r="1.5" fill="white"/>
+</g>
+<circle cx="16.5" cy="26.5" r="1" fill="white"/>
+<circle cx="50" cy="50" r="49.5" stroke="url(#paint8_linear_708_3996)"/>
+</g>
+<defs>
+<filter id="filter0_f_708_3996" x="84" y="38" width="7" height="7" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_708_3996"/>
+</filter>
+<filter id="filter1_f_708_3996" x="67" y="13" width="8" height="8" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_708_3996"/>
+</filter>
+<filter id="filter2_f_708_3996" x="25" y="25" width="9" height="9" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_708_3996"/>
+</filter>
+<filter id="filter3_f_708_3996" x="13" y="23" width="7" height="7" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="1" result="effect1_foregroundBlur_708_3996"/>
+</filter>
+<linearGradient id="paint0_linear_708_3996" x1="1.50003" y1="84" x2="119.5" y2="-2.99997" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFB5E1"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint1_linear_708_3996" x1="51.241" y1="87.8408" x2="51.241" y2="21.8585" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="0.984447" stop-color="#9D8DFF"/>
+</linearGradient>
+<linearGradient id="paint2_linear_708_3996" x1="69.5738" y1="112.065" x2="43.0627" y2="47.4013" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E3A8FF"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint3_linear_708_3996" x1="76" y1="83" x2="-12.054" y2="80.9644" gradientUnits="userSpaceOnUse">
+<stop offset="0.124772" stop-color="#BBA3FF"/>
+<stop offset="0.673429" stop-color="#FFD0FD"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint4_linear_708_3996" x1="66.1622" y1="52.8" x2="53.151" y2="42.5359" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A788FF"/>
+<stop offset="1" stop-color="#F5B5FF"/>
+</linearGradient>
+<linearGradient id="paint5_linear_708_3996" x1="64.2703" y1="60.8" x2="54.5555" y2="56.6198" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A788FF"/>
+<stop offset="1" stop-color="#F5B5FF"/>
+</linearGradient>
+<linearGradient id="paint6_linear_708_3996" x1="10.4084" y1="75.4157" x2="121.752" y2="95.0726" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9D8DFF"/>
+<stop offset="0.421875" stop-color="#E2BDFF"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint7_linear_708_3996" x1="36.0289" y1="71.5596" x2="74.1279" y2="103.095" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A893FB"/>
+<stop offset="0.390625" stop-color="#DCBAFF"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint8_linear_708_3996" x1="-2.90084e-07" y1="50.8197" x2="100" y2="50.8197" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A788FF"/>
+<stop offset="1" stop-color="#F5B5FF"/>
+</linearGradient>
+</defs>
+</svg>

--- a/packages/components/src/styles/layout.css.ts
+++ b/packages/components/src/styles/layout.css.ts
@@ -1,0 +1,11 @@
+import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
+
+const layoutProperties = defineProperties({
+  properties: {
+    display: ['none', 'block', 'inline', 'flex', 'inline-flex', 'grid'],
+    flexDirection: ['row', 'row-reverse', 'column', 'column-reverse'],
+  },
+  shorthands: { flex: ['flexDirection'] },
+});
+
+export const layoutSprinkles = createSprinkles(layoutProperties);

--- a/packages/components/src/styles/tools.ts
+++ b/packages/components/src/styles/tools.ts
@@ -4,7 +4,9 @@ import { calc } from '@vanilla-extract/css-utils';
 export const important = (css: string | number) => `${css} !important`;
 
 // colors
-export const createOutlineGradientBackgroundImage = (bgColor: string, gradient: string) => `linear-gradient(${bgColor}, ${bgColor}), ${gradient}`;
+export const createOutlineGradientBackgroundImage = (bgColor: string, gradient: string) =>
+  `linear-gradient(${bgColor}, ${bgColor}),${gradient}`;
+
 const opacityHex = {
   100: 'FF',
   99: 'FC',
@@ -108,7 +110,13 @@ const opacityHex = {
   1: '03',
   0: '00',
 };
-export const createHexWithOpacity = (color: string, value: keyof typeof opacityHex) => `${color}${opacityHex[value]}`;
+export const createHexWithOpacity = (color: string, value: keyof typeof opacityHex) =>
+  `${color}${opacityHex[value]}`;
 
 // spacing
 export const spacing = (px: number) => calc(px).divide(360).multiply('100%');
+
+// z-index
+const stackOrderType = { default: 0, dialog: 20, interaction: 30 };
+export type StackOrderType = 'default' | 'dialog' | 'interaction';
+export const setStackOrder = (type: StackOrderType = 'default') => stackOrderType[type];


### PR DESCRIPTION
### 기능이 무엇인가요?

- 다이얼로그에 적용 되는 svg 파일 추가
- layout 관련 css sprinkles 추가 (flex, flexDirection, etc)
- z-index css 설정해주는 함수 추가

### 해결책이 무엇 이니?

- prettier가 적용이 안되고 있었는데 eslint max-len 규칙이 자동으로 100 줄 이상으로 넘어가면 해결해주지 않고 에러만 내밭는 이슈가 있었어요. 그걸 해결하려고 eslint에 prettier도 적용 했습니다.
- 버튼 컴포넌트에 있는 버그 수정
   - `background` props 스타일 적용 안되는 이슈
   - Dialog 컴포넌트와 같이 스택 순서가 놓은 컴포넌트에 사용하기 위해 버튼 컴포넌틑에 `interaction` 스택 적용

### 사이트의 어떤 영역에 영향을 미칩니까?

(사이트의 어떤 부분이 영향을 받았는지 및 *if*코드가 다른 영역에 닿았는지 설명)

### 기타 참고 사항

(개발자 또는 QA 테스터에게 유용한 추가 정보 추가)

### 체크리스트

-   [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
-   [ ] 콘솔에 오류나 경고가 없습니다.

### Commit message

```
and :

-
```
