### PR TITLE
Add letter write page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,6 @@
   },
   "plugins": ["react", "@typescript-eslint", "prettier", "unused-imports", "simple-import-sort"],
   "rules": {
-    "prettier/prettier": ["error"],
-
     // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
     "react/jsx-filename-extension": [1, { "extensions": [".tsx"] }],
     "react/jsx-props-no-spreading": "off",
@@ -55,7 +53,7 @@
     ],
 
     // https://eslint.org/docs/latest/rules/object-curly-newline
-    "object-curly-newline": ["error", { "multiline": true }],
+    "object-curly-newline": ["error", { "multiline": true, "consistent": true }],
 
     // https://github.com/lydell/eslint-plugin-simple-import-sort
     "simple-import-sort/imports": "error",

--- a/packages/app/src/api/api-schema.d.ts
+++ b/packages/app/src/api/api-schema.d.ts
@@ -1,4 +1,19 @@
 declare namespace APISchema {
+  type LetterFormType = 'DRAFT' | 'DONE';
+
+  interface Letter {
+    userID?: string;
+    senderName?: string;
+    receiverName?: string;
+    receivedDate?: string; // "yyyy-MM-dd HH:mm:ss"
+    content?: string;
+    id?: string;
+    imageId?: string;
+    letterStatus?: LetterFormType;
+    receivedPhoneNumber?: string;
+    title?: string;
+  }
+
   interface User {
     id: string;
     username: string;

--- a/packages/app/src/api/index.ts
+++ b/packages/app/src/api/index.ts
@@ -4,3 +4,8 @@ export const authAPI = {
   authenticate: (token: string) =>
     instance.get<void, APISchema.User>(`/oauth/accessToken?token=${token}`),
 };
+
+export const letterAPI = {
+  addLetter: (letterPostRequest: APISchema.Letter) =>
+    instance.post('/v1/letter', letterPostRequest),
+};

--- a/packages/app/src/api/index.ts
+++ b/packages/app/src/api/index.ts
@@ -6,6 +6,6 @@ export const authAPI = {
 };
 
 export const letterAPI = {
-  addLetter: (letterPostRequest: APISchema.Letter) =>
-    instance.post('/v1/letter', letterPostRequest),
+  addLetter: (letterPostReq: APISchema.Letter) =>
+    instance.post<void, APISchema.Letter[]>('/v1/letter', letterPostReq),
 };

--- a/packages/app/src/index.css.ts
+++ b/packages/app/src/index.css.ts
@@ -23,6 +23,9 @@ globalStyle('ul', { listStyle: 'none' });
 globalStyle('li', { listStyle: 'none' });
 
 globalStyle('#root', {
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'flex-start',
   width: '100%',
   height: '100vh',
   minHeight: '100vh',

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -17,13 +17,13 @@ import './index.css';
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <StrictMode>
-    <BrowserRouter>
+    <RecoilRoot>
       <QueryClientProvider client={queryClient}>
-        <RecoilRoot>
+        <BrowserRouter>
           <Routes />
-        </RecoilRoot>
+        </BrowserRouter>
       </QueryClientProvider>
-    </BrowserRouter>
+    </RecoilRoot>
   </StrictMode>,
 );
 

--- a/packages/app/src/pages/App/SideBar/Sidebar.css.ts
+++ b/packages/app/src/pages/App/SideBar/Sidebar.css.ts
@@ -10,6 +10,7 @@ export const sideBarStyle = style({
   top: 0,
   width: '100%',
   height: '100vh',
+  pointerEvents: 'none',
 });
 
 export const backdropRecipe = recipe({
@@ -39,6 +40,7 @@ export const sideBarRecipe = recipe({
     height: '100%',
     width: '300px',
     transition: `transform ${vars.transitions.duration.fast} ${vars.transitions.timing.easeOut}`,
+    pointerEvents: 'auto',
   },
   variants: {
     visible: {

--- a/packages/app/src/pages/LetterForm/LetterForm.atoms.ts
+++ b/packages/app/src/pages/LetterForm/LetterForm.atoms.ts
@@ -1,0 +1,8 @@
+import moment from 'moment';
+import { atom } from 'recoil';
+
+export const letterFormState = atom<APISchema.Letter>({
+  key: 'letterForm',
+  // TODO 달력과 시간 선택 컴포넌트 생성 후 receivedDate 기본 값은 스텝 3에서 설정
+  default: { receivedDate: moment().add(1, 'd').format('YYYY-MM-DD HH:mm:ss') },
+});

--- a/packages/app/src/pages/LetterForm/LetterForm.css.ts
+++ b/packages/app/src/pages/LetterForm/LetterForm.css.ts
@@ -10,6 +10,7 @@ export const letterFormStyle = style({
   flexDirection: 'column',
   justifyContent: 'space-between',
   height: '100%',
+  paddingTop: '8px',
 });
 
 export const letterFormContentStyle = style({

--- a/packages/app/src/pages/LetterForm/LetterForm.css.ts
+++ b/packages/app/src/pages/LetterForm/LetterForm.css.ts
@@ -1,0 +1,28 @@
+import { style } from '@vanilla-extract/css';
+
+import { spacing } from '~components/styles/tools';
+
+const letterFormPaddingX = spacing(20);
+
+export const letterFormStyle = style({
+  flex: '1 1',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  height: '100%',
+});
+
+export const letterFormContentStyle = style({
+  flex: '1 1 auto',
+  display: 'flex',
+  flexDirection: 'column',
+  padding: `40px ${letterFormPaddingX}`,
+});
+
+export const letterFormActionsStyle = style({
+  display: 'flex',
+  padding: `${letterFormPaddingX}`,
+  marginBottom: 20,
+});
+
+export const letterFormActionButtonStyle = style({ width: 64 });

--- a/packages/app/src/pages/LetterForm/LetterForm.hooks.ts
+++ b/packages/app/src/pages/LetterForm/LetterForm.hooks.ts
@@ -38,5 +38,5 @@ export const useAddLetter = () => {
       // TODO add notification toast
       console.error(error);
     },
-  }).mutate;
+  }).mutateAsync;
 };

--- a/packages/app/src/pages/LetterForm/LetterForm.hooks.ts
+++ b/packages/app/src/pages/LetterForm/LetterForm.hooks.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { letterAPI } from '~/api';
+
+import { useValidateNameField } from './NameField/NameField.hooks';
+import { letterFormState } from './LetterForm.atoms';
+
+export const useValidateLetterForm = (activeStep: number) => {
+  const validateNameField = useValidateNameField();
+
+  return useCallback(() => {
+    if (activeStep === 1) {
+      return validateNameField();
+    }
+
+    if (activeStep === 2) {
+      return validateNameField();
+    }
+
+    return true;
+  }, [activeStep, validateNameField]);
+};
+
+export const useAddLetter = () => {
+  const [letterForm, setLetterForm] = useRecoilState(letterFormState);
+
+  return useMutation(() => letterAPI.addLetter(letterForm), {
+    onSuccess: ({ data }) => {
+      if (!data) {
+        return;
+      }
+      setLetterForm({ ...letterForm, id: data[0].id });
+    },
+    onError: (error) => {
+      // TODO add notification toast
+      console.error(error);
+    },
+  }).mutate;
+};

--- a/packages/app/src/pages/LetterForm/LetterForm.hooks.ts
+++ b/packages/app/src/pages/LetterForm/LetterForm.hooks.ts
@@ -4,6 +4,7 @@ import { useRecoilState } from 'recoil';
 import { useMutation } from '@tanstack/react-query';
 
 import { letterAPI } from '~/api';
+import { NotificationToaster } from '~components/index';
 
 import { useValidateNameField } from './NameField/NameField.hooks';
 import { letterFormState } from './LetterForm.atoms';
@@ -28,15 +29,11 @@ export const useAddLetter = () => {
   const [letterForm, setLetterForm] = useRecoilState(letterFormState);
 
   return useMutation(() => letterAPI.addLetter(letterForm), {
-    onSuccess: ({ data }) => {
-      if (!data) {
-        return;
-      }
-      setLetterForm({ ...letterForm, id: data[0].id });
+    onSuccess: (data) => {
+      setLetterForm({ ...letterForm, id: data[0]?.id });
     },
-    onError: (error) => {
-      // TODO add notification toast
-      console.error(error);
+    onError: () => {
+      NotificationToaster.show('편지 저장에 실패했습니다.');
     },
   }).mutateAsync;
 };

--- a/packages/app/src/pages/LetterForm/LetterForm.tsx
+++ b/packages/app/src/pages/LetterForm/LetterForm.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { state } from '~/store';
+import { Button, ProgressBar } from '~components/index';
+
+import LetterFormContent from './LetterFormContent/LetterFormContent';
+import { letterFormState } from './LetterForm.atoms';
+import {
+  letterFormActionButtonStyle,
+  letterFormActionsStyle,
+  letterFormContentStyle,
+  letterFormStyle,
+} from './LetterForm.css';
+import { useAddLetter, useValidateLetterForm } from './LetterForm.hooks';
+
+const totalSteps = 5;
+
+function LetterForm() {
+  const { nickname, username, id: userID } = useRecoilValue(state.user);
+  const [letterForm, setLetterForm] = useRecoilState(letterFormState);
+
+  const [step, setStep] = useState<number>(1);
+
+  useEffect(() => {
+    setLetterForm((prev) => ({
+      ...prev,
+      userID,
+      senderName: nickname ?? username,
+    }));
+  }, []);
+
+  const validateLetterForm = useValidateLetterForm(step);
+  const addLetter = useAddLetter();
+  const handleNextClick = async () => {
+    if (!validateLetterForm()) {
+      return;
+    }
+
+    if (!letterForm.id) {
+      await addLetter();
+    }
+    setStep((prev) => prev + 1);
+  };
+
+  const handlePrevClick = () => {
+    setStep((prev) => prev - 1);
+  };
+
+  return (
+    <div className={letterFormStyle}>
+      <ProgressBar steps={totalSteps} activeStep={step} />
+      <div className={letterFormContentStyle}>
+        <LetterFormContent activeStep={step} />
+      </div>
+      <div className={letterFormActionsStyle}>
+        {step > 1 && (
+          <Button.Prev className={letterFormActionButtonStyle} onClick={handlePrevClick} />
+        )}
+        <Button.Next
+          className={letterFormActionButtonStyle}
+          onClick={handleNextClick}
+          style={{
+            marginLeft: 'auto',
+            alignSelf: 'flex-end',
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default LetterForm;

--- a/packages/app/src/pages/LetterForm/LetterForm.tsx
+++ b/packages/app/src/pages/LetterForm/LetterForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import { state } from '~/store';
+import { userState } from '~/store/user.atoms';
 import { Button, ProgressBar } from '~components/index';
 
 import LetterFormContent from './LetterFormContent/LetterFormContent';
@@ -17,18 +17,21 @@ import { useAddLetter, useValidateLetterForm } from './LetterForm.hooks';
 const totalSteps = 5;
 
 function LetterForm() {
-  const { nickname, username, id: userID } = useRecoilValue(state.user);
+  const user = useRecoilValue(userState);
   const [letterForm, setLetterForm] = useRecoilState(letterFormState);
 
   const [step, setStep] = useState<number>(1);
 
   useEffect(() => {
-    setLetterForm((prev) => ({
-      ...prev,
-      userID,
-      senderName: nickname ?? username,
-    }));
-  }, []);
+    if (!user) {
+      return;
+    }
+    setLetterForm({
+      ...letterForm,
+      userID: user.id,
+      senderName: user.name,
+    });
+  }, [user.name, user.id]);
 
   const validateLetterForm = useValidateLetterForm(step);
   const addLetter = useAddLetter();
@@ -59,11 +62,8 @@ function LetterForm() {
         )}
         <Button.Next
           className={letterFormActionButtonStyle}
+          style={{ marginLeft: 'auto' }}
           onClick={handleNextClick}
-          style={{
-            marginLeft: 'auto',
-            alignSelf: 'flex-end',
-          }}
         />
       </div>
     </div>

--- a/packages/app/src/pages/LetterForm/LetterFormContent/LetterFormContent.tsx
+++ b/packages/app/src/pages/LetterForm/LetterFormContent/LetterFormContent.tsx
@@ -1,0 +1,21 @@
+import { Text } from '~components/index';
+
+import ReceiverField from '../ReceiverField/ReceiverField';
+import SenderField from '../SenderField/SenderField';
+
+import { LetterFormContentProps } from './LetterFormContent.types';
+
+function LetterFormContent(props: LetterFormContentProps) {
+  const { activeStep } = props;
+
+  switch (activeStep) {
+    case 1:
+      return <SenderField />;
+    case 2:
+      return <ReceiverField />;
+    default:
+      return <Text color="white">작업중</Text>;
+  }
+}
+
+export default LetterFormContent;

--- a/packages/app/src/pages/LetterForm/LetterFormContent/LetterFormContent.types.ts
+++ b/packages/app/src/pages/LetterForm/LetterFormContent/LetterFormContent.types.ts
@@ -1,0 +1,3 @@
+export interface LetterFormContentProps {
+  activeStep: number;
+}

--- a/packages/app/src/pages/LetterForm/NameField/NameField.atoms.ts
+++ b/packages/app/src/pages/LetterForm/NameField/NameField.atoms.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+import { NameFieldState } from './NameField.types';
+
+export const nameFieldState = atom<NameFieldState>({
+  key: 'letterForm.nameField',
+  default: { name: '' },
+});

--- a/packages/app/src/pages/LetterForm/NameField/NameField.hooks.ts
+++ b/packages/app/src/pages/LetterForm/NameField/NameField.hooks.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { nameFieldState } from './NameField.atoms';
+
+export const useValidateNameField = () => {
+  const [nameField, setNameField] = useRecoilState(nameFieldState);
+
+  return useCallback(() => {
+    const { name } = nameField;
+    let errorMessage = '';
+
+    if (name && name.length < 10) {
+      return true;
+    }
+    if (!name?.trim()) {
+      errorMessage = '이름을 입력해주세요';
+    }
+    if ((name || '').length > 10) {
+      errorMessage = '이름은 10글자 이내로 적어주세요.';
+    }
+
+    setNameField({
+      ...nameField,
+      errorMessage,
+    });
+    return false;
+  }, [nameField.name]);
+};

--- a/packages/app/src/pages/LetterForm/NameField/NameField.tsx
+++ b/packages/app/src/pages/LetterForm/NameField/NameField.tsx
@@ -1,0 +1,57 @@
+import { ChangeEvent, useEffect, useRef } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { InputField, TextInput } from '~components/index';
+
+import { nameFieldState } from './NameField.atoms';
+import { NameFieldProps } from './NameField.types';
+
+const maxLength = 10;
+
+function NameField(props: NameFieldProps) {
+  const { name: nameFromParent, onBlur, children: heading, placeholder } = props;
+  const [nameField, setNameField] = useRecoilState(nameFieldState);
+  const { name, errorMessage } = nameField;
+
+  useEffect(() => {
+    setNameField({ name: nameFromParent });
+  }, [nameFromParent]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, [nameField.errorMessage]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    if (value.length > maxLength) {
+      return;
+    }
+    setNameField({ name: value });
+  };
+
+  const handleBlur = (_: ChangeEvent<HTMLInputElement>) => {
+    onBlur(name.trim());
+  };
+
+  return (
+    <div>
+      {heading}
+
+      <InputField errorMessage={errorMessage}>
+        <TextInput
+          ref={inputRef}
+          style={{ marginTop: 28 }}
+          type="text"
+          placeholder={placeholder}
+          maxLength={maxLength}
+          value={name}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
+      </InputField>
+    </div>
+  );
+}
+
+export default NameField;

--- a/packages/app/src/pages/LetterForm/NameField/NameField.types.ts
+++ b/packages/app/src/pages/LetterForm/NameField/NameField.types.ts
@@ -1,0 +1,13 @@
+import { ReactElement } from 'react';
+
+export interface NameFieldState {
+  name: string;
+  errorMessage?: string;
+}
+
+export interface NameFieldProps {
+  children: ReactElement;
+  name: string;
+  placeholder?: string;
+  onBlur: (name: string) => void;
+}

--- a/packages/app/src/pages/LetterForm/ReceiverField/ReceiverField.tsx
+++ b/packages/app/src/pages/LetterForm/ReceiverField/ReceiverField.tsx
@@ -1,0 +1,35 @@
+import { useRecoilState } from 'recoil';
+
+import { Text } from '~components/index';
+
+import { letterFormState } from '../LetterForm.atoms';
+import NameField from '../NameField/NameField';
+
+function ReceiverField() {
+  const [letterForm, setLetterForm] = useRecoilState(letterFormState);
+
+  const handleReceiverBlur = (value: string) => {
+    setLetterForm({ ...letterForm, receiverName: value });
+  };
+
+  return (
+    <div>
+      <NameField
+        name={letterForm.receiverName ?? ''}
+        placeholder={letterForm.receiverName}
+        onBlur={handleReceiverBlur}
+      >
+        <Text as="h2" color="white" size={4}>
+          <Text as="span" color="secondary" size={4}>
+            누구에게
+          </Text>
+          편지를 보낼까요?
+          <br />
+          이름이나 애칭도 좋아요.
+        </Text>
+      </NameField>
+    </div>
+  );
+}
+
+export default ReceiverField;

--- a/packages/app/src/pages/LetterForm/SenderField/SenderField.tsx
+++ b/packages/app/src/pages/LetterForm/SenderField/SenderField.tsx
@@ -1,0 +1,35 @@
+import { useRecoilState } from 'recoil';
+
+import { Text } from '~components/index';
+
+import { letterFormState } from '../LetterForm.atoms';
+import NameField from '../NameField/NameField';
+
+function SenderField() {
+  const [letterForm, setLetterForm] = useRecoilState(letterFormState);
+
+  const handleSenderBlur = (value: string) => {
+    setLetterForm({ ...letterForm, senderName: value });
+  };
+
+  return (
+    <div>
+      <NameField
+        placeholder={letterForm.senderName}
+        name={letterForm.senderName ?? ''}
+        onBlur={handleSenderBlur}
+      >
+        <Text as="h2" color="white" size={4}>
+          <Text as="span" color="secondary" size={4}>
+            내 이름
+          </Text>
+          을
+          <br />
+          먼저 적어볼까요?
+        </Text>
+      </NameField>
+    </div>
+  );
+}
+
+export default SenderField;

--- a/packages/app/src/pages/LetterForm/SenderField/SenderField.tsx
+++ b/packages/app/src/pages/LetterForm/SenderField/SenderField.tsx
@@ -12,6 +12,10 @@ function SenderField() {
     setLetterForm({ ...letterForm, senderName: value });
   };
 
+  if (!letterForm.senderName) {
+    return null;
+  }
+
   return (
     <div>
       <NameField

--- a/packages/app/src/pages/Main/Main.tsx
+++ b/packages/app/src/pages/Main/Main.tsx
@@ -4,8 +4,8 @@ import { mainBodyStyle } from './Main.css';
 function Main() {
   return (
     <div className={mainBodyStyle}>
-      <MainBox menuName="편지쓰기" path="/" />
-      <MainBox menuName="보낸편지함" path="/letterBox" />
+      <MainBox menuName="편지쓰기" path="/letter/write" />
+      <MainBox menuName="보낸편지함" path="/letter/box" />
     </div>
   );
 }

--- a/packages/app/src/pages/Routes.tsx
+++ b/packages/app/src/pages/Routes.tsx
@@ -5,6 +5,7 @@ import App from '~/pages/App/App';
 import { getCookie } from '~utils/cookies';
 
 import LetterBox from './LetterBox/LetterBox';
+import LetterForm from './LetterForm/LetterForm';
 import Login from './Login/Login';
 import LoginIntro from './Login/LoginIntro/LoginIntro';
 import Main from './Main/Main';
@@ -31,9 +32,13 @@ function Routes() {
 
       <Route path="/" element={<App />}>
         <Route path="/" element={<Main />} />
-        <Route path="/reminder" element={<Reminder />} />
-        <Route path="/myPage" element={<MyPage />} />
-        <Route path="/letterBox" element={<LetterBox />} />
+        <Route path="reminder" element={<Reminder />} />
+        <Route path="myPage" element={<MyPage />} />
+
+        <Route path="letter">
+          <Route path="box" element={<LetterBox />} />
+          <Route path="write" element={<LetterForm />} />
+        </Route>
       </Route>
     </Switch>
   );

--- a/packages/components/src/NotificationToaster/NotificationToaster.css.ts
+++ b/packages/components/src/NotificationToaster/NotificationToaster.css.ts
@@ -1,0 +1,20 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { colorSystem } from '../styles/colors.css';
+import { vars } from '../styles/global.css';
+import { hideStyle } from '../styles/layout.css';
+import { createHexWithOpacity } from '../styles/tools';
+
+export const notificationToasterStyle = style({
+  color: vars.colors.white,
+  textAlign: 'center',
+});
+
+globalStyle(`${notificationToasterStyle} .bp4-toast`, {
+  backgroundColor: createHexWithOpacity(colorSystem.gray900, 50),
+  border: 0,
+  borderRadius: 4,
+  boxShadow: 'none',
+});
+
+globalStyle(`${notificationToasterStyle} .bp4-button-group`, hideStyle);

--- a/packages/components/src/NotificationToaster/NotificationToaster.stories.tsx
+++ b/packages/components/src/NotificationToaster/NotificationToaster.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Button from '../Button/Button';
+
+import NotificationToaster from './NotificationToaster';
+
+export default {
+  title: 'Feedback/NotificationToaster',
+  component: NotificationToaster,
+} as ComponentMeta<typeof NotificationToaster>;
+
+const Templates: ComponentStory<typeof NotificationToaster> = (args) => (
+  <NotificationToaster {...args} />
+);
+
+export const Base = Templates.bind({});
+Base.args = {
+  message: '편지가 임시저장 되었습니다.',
+};
+
+const UsageTemplates: ComponentStory<typeof NotificationToaster> = () => {
+  const handleClick = () => {
+    NotificationToaster.show('편지가 임시저장 되었습니다.');
+  };
+  return <Button label="보내기" onClick={handleClick} />;
+};
+export const Usage = UsageTemplates.bind({});

--- a/packages/components/src/NotificationToaster/NotificationToaster.tsx
+++ b/packages/components/src/NotificationToaster/NotificationToaster.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useId, useRef } from 'react';
+import classNames from 'classnames';
+
+import { Position, Toast, Toaster } from '@blueprintjs/core';
+
+import { notificationToasterStyle } from './NotificationToaster.css';
+import { NotificationToasterProps } from './NotificationToaster.types';
+
+function NotificationToaster(props: NotificationToasterProps) {
+  const { className, message } = props;
+
+  const toasterRef = useRef<Toaster>(null);
+  const uniqueId = useId();
+
+  useEffect(
+    () => () => {
+      toasterRef.current?.dismiss(uniqueId);
+    },
+    [],
+  );
+
+  return (
+    <Toaster
+      ref={toasterRef}
+      className={classNames(notificationToasterStyle, className)}
+      position={Position.TOP}
+      key={uniqueId}
+    >
+      <Toast message={message} />
+    </Toaster>
+  );
+}
+
+const Notification = Toaster.create({
+  className: classNames(notificationToasterStyle),
+  position: Position.TOP,
+});
+
+const NotificationFn = (message: string) =>
+  // useEffect(
+  //   () => () => {
+  //     Notification.clear();
+  //   },
+  //   [],
+  // );
+
+  Notification.show({ message });
+export default Object.assign(NotificationToaster, {
+  show: NotificationFn,
+});

--- a/packages/components/src/NotificationToaster/NotificationToaster.types.ts
+++ b/packages/components/src/NotificationToaster/NotificationToaster.types.ts
@@ -1,0 +1,5 @@
+import { ToastProps } from '@blueprintjs/core';
+
+export interface NotificationToasterProps extends Pick<ToastProps, 'className'> {
+  message?: string;
+}

--- a/packages/components/src/TextInput/TextInput.tsx
+++ b/packages/components/src/TextInput/TextInput.tsx
@@ -1,12 +1,13 @@
+import { ForwardedRef, forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { inputStyle } from '../styles/input.css';
 
 import { TextInputProps } from './TextInput.types';
 
-function TextInput(props: TextInputProps) {
+function TextInput(props: TextInputProps, ref: ForwardedRef<HTMLInputElement>) {
   const { className, type, ...rest } = props;
-  return <input className={classNames(inputStyle, className)} type={type} {...rest} />;
+  return <input ref={ref} className={classNames(inputStyle, className)} type={type} {...rest} />;
 }
-
-export default TextInput;
+TextInput.displayName = 'TextInput';
+export default forwardRef<HTMLInputElement, TextInputProps>(TextInput);

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -4,6 +4,7 @@ export { default as Button } from './Button/Button';
 export { default as Heading } from './Heading/Heading';
 export { default as InputField } from './InputField/InputField';
 export { default as MailBox } from './MailBox/MailBox';
+export { default as NotificationToaster } from './NotificationToaster/NotificationToaster';
 export { default as NumberInput } from './NumberInput/NumberInput';
 export { default as ProgressBar } from './ProgressBar/ProgressBar';
 export { default as Text } from './Text/Text';

--- a/packages/components/src/styles/layout.css.ts
+++ b/packages/components/src/styles/layout.css.ts
@@ -1,5 +1,7 @@
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 
+import { important } from './tools';
+
 const layoutProperties = defineProperties({
   properties: {
     display: ['none', 'block', 'inline', 'flex', 'inline-flex', 'grid'],
@@ -7,5 +9,18 @@ const layoutProperties = defineProperties({
   },
   shorthands: { flex: ['flexDirection'] },
 });
+
+export const hideStyle = {
+  position: important('absolute') as 'absolute',
+  width: important('1px'),
+  height: important('1px'),
+  padding: important(0),
+  margin: important('-1px'),
+  overflow: important('hidden'),
+  clip: important('rect(0, 0, 0, 0)'),
+  whiteSpace: important('nowrap') as 'nowrap',
+  border: important(0),
+};
+
 
 export const layoutSprinkles = createSprinkles(layoutProperties);


### PR DESCRIPTION
### 기능이 무엇인가요?

- 편지쓰기 페이지 생성
- 편지쓰기 보내는이 (스텝1)
   - 다음 스텝으로 넘어갈때 `senderName` 데이터로 편지 한번 저장 (POST)
   - 받아온 편지 id 값을 나중에 사진 저장할때 사용할 예정
- 편지쓰기 받는이 (스텝2)
- 메인의 편지쓰기 링크 수정
- 토스트 노티 컴포넌트 추가 (NotificationToaster)

### 해결책이 무엇 이니?

- SideBar 바닥 DOM 레이어가 항상 있어 클릭이 안되는 이슈 해결  896676c

### 사이트의 어떤 영역에 영향을 미칩니까?

(사이트의 어떤 부분이 영향을 받았는지 및 *if*코드가 다른 영역에 닿았는지 설명)

### 기타 참고 사항

(개발자 또는 QA 테스터에게 유용한 추가 정보 추가)

### 체크리스트

-   [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
-   [ ] 콘솔에 오류나 경고가 없습니다.

### Commit message

```
and :

-
```
