### PR TITLE
Implement logout

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -3,7 +3,6 @@ const env = {
   localURL: process.env.REACT_APP_LOCAL,
   kakaoKey: process.env.REACT_APP_KAKAO_API_KEY,
   kakaoLogin: `${process.env.REACT_APP_KAKAO_API_LOGIN_URL}&client_id=${process.env.REACT_APP_KAKAO_API_KEY}&redirect_uri=${process.env.REACT_APP_LOCAL}/login&prompt=login`,
-  kakaoLogOut: `${process.env.REACT_APP_KAKAO_API_LOGOUT_URL}?client_id=${process.env.REACT_APP_KAKAO_API_KEY}&logout_redirect_uri=${process.env.REACT_APP_LOCAL}/login`,
   kakaoToken: process.env.REACT_APP_KAKAO_API_ACCESS_TOKEN,
 };
 

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -2,7 +2,8 @@ const env = {
   apiURL: process.env.REACT_APP_API_URL,
   localURL: process.env.REACT_APP_LOCAL,
   kakaoKey: process.env.REACT_APP_KAKAO_API_KEY,
-  kakaoLogin: `${process.env.REACT_APP_KAKAO_API_LOGIN_URL}&client_id=${process.env.REACT_APP_KAKAO_API_KEY}&redirect_uri=${process.env.REACT_APP_LOCAL}/login`,
+  kakaoLogin: `${process.env.REACT_APP_KAKAO_API_LOGIN_URL}&client_id=${process.env.REACT_APP_KAKAO_API_KEY}&redirect_uri=${process.env.REACT_APP_LOCAL}/login&prompt=login`,
+  kakaoLogOut: `${process.env.REACT_APP_KAKAO_API_LOGOUT_URL}?client_id=${process.env.REACT_APP_KAKAO_API_KEY}&logout_redirect_uri=${process.env.REACT_APP_LOCAL}/login`,
   kakaoToken: process.env.REACT_APP_KAKAO_API_ACCESS_TOKEN,
 };
 

--- a/packages/app/src/pages/App/SideBar/SideBar.tsx
+++ b/packages/app/src/pages/App/SideBar/SideBar.tsx
@@ -1,7 +1,6 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
-import env from '~/config';
-import { removeUserState } from '~/store/user.atoms';
+import persistStore from '~/store/persistStore';
 import { ReactComponent as CancelIcon } from '~components/assets/icons/cancel.svg';
 import Dialog from '~components/Dialog/Dialog';
 import { useDialog } from '~components/Dialog/Dialog.hooks';
@@ -23,13 +22,12 @@ function SideBar(props: SideBarProps) {
   const { open, onClose } = props;
   const { isOpen, handleOpenDialog, handleCloseDialog } = useDialog();
 
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
 
   const handleLogOut = () => {
-    handleCloseDialog();
     removeCookie('token');
-    removeUserState();
-    window.location.href = env.kakaoLogOut;
+    persistStore.dropInstance({ name: 'persistState' });
+    navigate('/login', { replace: true });
   };
 
   const tabIndex = open ? 0 : -1;

--- a/packages/app/src/pages/App/SideBar/SideBar.tsx
+++ b/packages/app/src/pages/App/SideBar/SideBar.tsx
@@ -1,7 +1,12 @@
 import { Link } from 'react-router-dom';
 
+import env from '~/config';
+import { removeUserState } from '~/store/user.atoms';
 import { ReactComponent as CancelIcon } from '~components/assets/icons/cancel.svg';
+import Dialog from '~components/Dialog/Dialog';
+import { useDialog } from '~components/Dialog/Dialog.hooks';
 import { Button, Text } from '~components/index';
+import { removeCookie } from '~utils/cookies';
 
 import { sideBarMenuList } from './SideBar.const';
 import {
@@ -16,6 +21,16 @@ import { SideBarProps } from './Sidebar.type';
 
 function SideBar(props: SideBarProps) {
   const { open, onClose } = props;
+  const { isOpen, handleOpenDialog, handleCloseDialog } = useDialog();
+
+  // const navigate = useNavigate();
+
+  const handleLogOut = () => {
+    handleCloseDialog();
+    removeCookie('token');
+    removeUserState();
+    window.location.href = env.kakaoLogOut;
+  };
 
   const tabIndex = open ? 0 : -1;
 
@@ -52,13 +67,27 @@ function SideBar(props: SideBarProps) {
             </li>
           ))}
           <li className={logoutStyle}>
-            <Button tabIndex={tabIndex} variant="transparent" label="">
+            <Button tabIndex={tabIndex} variant="transparent" label="" onClick={handleOpenDialog}>
               <Text as="span" size={2} color="white">
                 로그아웃
               </Text>
             </Button>
           </li>
         </ul>
+        <Dialog isOpen={isOpen} style={{ width: 350 }}>
+          <Dialog.Content>
+            <Text as="p">로그아웃 하시겠습니까?</Text>
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button
+              label="취소"
+              variant="outline"
+              borderColor="gradient"
+              onClick={handleCloseDialog}
+            />
+            <Button label="확인" background="gradient" onClick={handleLogOut} />
+          </Dialog.Actions>
+        </Dialog>
       </div>
     </div>
   );

--- a/packages/app/src/store/user.atoms.ts
+++ b/packages/app/src/store/user.atoms.ts
@@ -35,3 +35,7 @@ export const userState = atom<UserState>({
     },
   ],
 });
+
+export const removeUserState = async () => {
+  persistStore.dropInstance({ name: 'persistState' });
+};

--- a/packages/app/src/store/user.atoms.ts
+++ b/packages/app/src/store/user.atoms.ts
@@ -35,7 +35,3 @@ export const userState = atom<UserState>({
     },
   ],
 });
-
-export const removeUserState = async () => {
-  persistStore.dropInstance({ name: 'persistState' });
-};

--- a/packages/app/src/utils/cookies.ts
+++ b/packages/app/src/utils/cookies.ts
@@ -6,4 +6,8 @@ export const setCookie = (name: string, value: string, option: CookieSetOptions)
   cookies.set(name, value, { ...option });
 };
 
+export const removeCookie = (name: string) => {
+  cookies.remove(name);
+};
+
 export const getCookie = (name: string) => cookies.get(name);


### PR DESCRIPTION
* 로그아웃 기능 추가
* 쿠키 삭제 추가
* config 수정 (카카오 로그아웃 추가)
* env 파일 추가

### 기능이 무엇인가요?

로그아웃시   쿠키삭제 -> DB 제거 -> 카카오 로그아웃 플로우 
카카오 로그인시 PC 환경을 고려하여 매번 아이디 패스워드 입력페이지 이동 파라미터 추가

### 해결책이 무엇 이니?

### 사이트의 어떤 영역에 영향을 미칩니까?

1. 로그아웃시 카카오 로그아웃 페이지로 이동하며  서비스 로그아웃 기능 수행
2. 카카오 로그인시 PC 환경을 고려하여 매번 아이디 패스워드 입력페이지로 이동

### 기타 참고 사항

1. DB 사용시 개인정보 그대로 표시되므로 암호화 검토 필요 
![image](https://user-images.githubusercontent.com/53326835/188402214-4181f2c4-84cb-448e-a58d-3432fe55d87f.png)


### 체크리스트

-   [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
-   [ ] 콘솔에 오류나 경고가 없습니다.
