### PR TITLE
* reminder api 수정

### DIFF
--- a/packages/app/src/api/api-schema.d.ts
+++ b/packages/app/src/api/api-schema.d.ts
@@ -12,7 +12,8 @@ declare namespace APISchema {
     letterStatus?: LetterStatus;
     receivedPhoneNumber?: string;
     title?: string;
-    createdAt?: string; // "yyyy-MM-dd HH:mm:ss"
+    createdAt?: string; // "yyyy-MM-dd HH:mm:ss"\
+    urlSlug?: string;
   }
 
   interface LetterPutReq
@@ -26,6 +27,7 @@ declare namespace APISchema {
         | 'receivedDate'
         | 'content'
         | 'letterStatus'
+        | 'urlSlug'
       >
     > {
     imageId?: Letter['imageId'];
@@ -42,6 +44,7 @@ declare namespace APISchema {
     senderName: NonNullable<Letter['senderName']>;
     letterStatus: NonNullable<Letter['letterStatus']>;
     createdAt: NonNullable<Letter['createAt']>;
+    urlSlug: NonNullable<Letter['urlSlug']>;
     imageId?: string;
     image?: string;
   }

--- a/packages/app/src/api/index.ts
+++ b/packages/app/src/api/index.ts
@@ -38,7 +38,7 @@ export const letterAPI = {
 
 export const reminderAPI = {
   reminderLetter: (uuid: string) =>
-    instance.get<void, APISchema.Letter[]>(`/v1/letter/receive/${uuid}`),
+    instance.get<void, APISchema.Letter[]>(`/v1/letter/urlSlug/${uuid}`),
   reminderUpdate: (data?: APISchema.ReminderUpDateType) =>
     instance.post<void, APISchema.ReminderUpDateType>('/v1/reminder', data, {
       headers: { 'Content-Type': 'multipart/form-data' },

--- a/packages/app/src/hooks/index.ts
+++ b/packages/app/src/hooks/index.ts
@@ -27,7 +27,7 @@ export const useImageDataURLState = (
 };
 
 export const useGetImageByImageId = (imageId?: string, enabled = false) =>
-  useQuery(['letterImage', imageId], () => letterAPI.getImageByImageId(imageId!), {
+  useQuery(['letterImage', imageId], () => letterAPI.getImageByImageId(imageId || ''), {
     enabled: !!imageId && enabled,
   });
 

--- a/packages/app/src/pages/LetterForm/LetterForm.tsx
+++ b/packages/app/src/pages/LetterForm/LetterForm.tsx
@@ -47,7 +47,7 @@ function LetterForm() {
 
     if (step === 2 && !letterForm.id) {
       const data = await addLetter();
-      setLetterForm({ ...letterForm, id: data[0]?.id });
+      setLetterForm({ ...letterForm, id: data[0]?.id, urlSlug: data[0]?.urlSlug });
     }
     setStep((prev) => prev + 1);
   };

--- a/packages/app/src/pages/LetterForm/LetterPreview/LetterPreview.hooks.ts
+++ b/packages/app/src/pages/LetterForm/LetterPreview/LetterPreview.hooks.ts
@@ -10,10 +10,10 @@ export const useShareWithKakao = () => {
   const setStep = useSetRecoilState(letterFormStepState);
 
   return ({
-    id,
     senderName,
     receivedDate,
-  }: Required<Pick<APISchema.Letter, 'id' | 'senderName' | 'receivedDate'>>) => {
+    urlSlug,
+  }: Required<Pick<APISchema.Letter, 'senderName' | 'receivedDate' | 'urlSlug'>>) => {
     if (!kakao.isInitialized()) {
       kakao.init(env.kakaoShareKey);
     }
@@ -25,7 +25,7 @@ export const useShareWithKakao = () => {
       templateArgs: {
         name: `\nFrom. ${senderName}`,
         day: `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 `,
-        linkUrl: `reminder/${id}`,
+        linkUrl: `reminder/${urlSlug}`,
       },
       success: () => {
         setStep(6);

--- a/packages/app/src/pages/LetterForm/LetterPreview/LetterPreview.tsx
+++ b/packages/app/src/pages/LetterForm/LetterPreview/LetterPreview.tsx
@@ -13,7 +13,7 @@ import { letterFormState, letterFormStepState, letterImageState } from '../Lette
 
 function LetterPreview() {
   const letterImage = useRecoilValue(letterImageState);
-  const { userID, id, receivedDate, senderName, receiverName, content, imageId } =
+  const { userID, id, receivedDate, senderName, receiverName, content, imageId, urlSlug } =
     useRecoilValue(letterFormState);
   const setStep = useSetRecoilState(letterFormStepState);
 
@@ -36,7 +36,7 @@ function LetterPreview() {
 
   const shareWithKakao = useShareWithKakao();
   const sendLetter = async () => {
-    if (!userID || !id || !receivedDate || !senderName || !receiverName || !content) {
+    if (!userID || !id || !receivedDate || !senderName || !receiverName || !content || !urlSlug) {
       return;
     }
     await saveLetter({
@@ -47,9 +47,10 @@ function LetterPreview() {
       receiverName,
       content,
       imageId,
+      urlSlug,
       letterStatus: 'DONE',
     });
-    shareWithKakao({ id, receivedDate, senderName });
+    shareWithKakao({ receivedDate, senderName, urlSlug });
   };
 
   const isPastDate = useIsPastDate();


### PR DESCRIPTION
### 기능이 무엇인가요?

reminder api 수정 
-- reminder 호출 방식 urlSlug 로 변경 및 letter 타입 추가 

### 해결책이 무엇 이니?

(기능이 구현된 방식을 개략적으로 설명)

### 사이트의 어떤 영역에 영향을 미칩니까?

letter urlSlug 타입 추가 및 기존 리마인더 페이지는 동작 불가능 

### 기타 참고 사항

(개발자 또는 QA 테스터에게 유용한 추가 정보 추가)

### 체크리스트

-   [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
-   [ ] 콘솔에 오류나 경고가 없습니다.
